### PR TITLE
SV-48: Sign Up View

### DIFF
--- a/Codebase/Aureus-Package/lib/Core/foundation.dart
+++ b/Codebase/Aureus-Package/lib/Core/foundation.dart
@@ -464,7 +464,7 @@ class ButtonBackingDecoration extends BaseBackingDecoration {
       decorationCornerRadius = 0.0;
     } else if (variant == buttonDecorationVariants.roundedPill) {
       decorationShape = BoxShape.rectangle;
-      decorationCornerRadius = BorderRadius.circular(30.0) as double;
+      decorationCornerRadius = 30.0;
     } else if (variant == buttonDecorationVariants.roundedRectangle) {
       decorationShape = BoxShape.rectangle;
       decorationCornerRadius = 7.0;
@@ -488,9 +488,11 @@ class ButtonBackingDecoration extends BaseBackingDecoration {
       if (mode == modeVariants.light) {
         decorationFill = foundation.frost();
         decorationBorder = foundation.universalBorder();
+        decorationGradient = foundation.lightGradient();
       } else if (mode == modeVariants.dark) {
         decorationFill = foundation.carbon();
         decorationBorder = foundation.universalBorder();
+        decorationGradient = foundation.darkGradient();
       }
     }
 

--- a/Codebase/Aureus-Package/lib/Widgets/Components/Alert Controllers/FullWidthAlertControllerComponent.dart
+++ b/Codebase/Aureus-Package/lib/Widgets/Components/Alert Controllers/FullWidthAlertControllerComponent.dart
@@ -5,82 +5,81 @@ import 'package:flutter/cupertino.dart';
 //A full width centered alert controller that sticks to the bottom of the screen
 //Doc Link:
 
-class FullWidthAlertControllerComponent extends StatefulWidget {
-  final AlertControllerObject alertData;
+class FullWidthButtonElement extends StatefulWidget {
+  final String buttonTitle;
+  final buttonVariants currentVariant;
+  final VoidCallback buttonAction;
 
-  const FullWidthAlertControllerComponent({required this.alertData});
+  const FullWidthButtonElement(
+      {required this.buttonTitle,
+      required this.currentVariant,
+      required this.buttonAction});
 
   @override
-  _FullWidthAlertControllerComponentState createState() =>
-      _FullWidthAlertControllerComponentState();
+  _FullWidthButtonElementState createState() => _FullWidthButtonElementState();
 }
 
-class _FullWidthAlertControllerComponentState
-    extends State<FullWidthAlertControllerComponent> {
+class _FullWidthButtonElementState extends State<FullWidthButtonElement> {
+  final foundation = new UDSVariables();
   @override
   Widget build(BuildContext context) {
-    Expanded alertControllerActions =
-        Expanded(child: Container(width: 10, height: 10));
+    //to fully have the custom functionality wanted, buttons needed to be a pressable container that holds a text button instead of a stock button widget.
 
-    if (widget.alertData.actions.length == 1) {
-      //needs a single full width button
+    //variables that change how the variants are displayed in build time
+    BoxDecoration buttonDecoration;
+    bool isButtonEnabled;
+    Color buttonTextColor;
 
-      var actionItem = widget.alertData.actions[0];
+    switch (widget.currentVariant) {
+      case buttonVariants.inactive:
 
-      alertControllerActions = Expanded(
-          child: FullWidthButtonElement(
-        buttonAction: actionItem.onSelection,
-        buttonTitle: actionItem.actionName,
-        currentVariant: buttonVariants.darkActive,
-      ));
-    } else if (widget.alertData.actions.length >= 2) {
-      //needs stacked standards button built to severity
-      alertControllerActions = Expanded(
-          child: ListView.builder(
-              scrollDirection: Axis.vertical,
-              itemCount: widget.alertData.actions.length,
-              itemBuilder: (BuildContext context, int index) {
-                AlertControllerAction actionItem =
-                    widget.alertData.actions[index];
+        //variables that define the variant 'inactive' for full width buttons
+        isButtonEnabled = false;
+        buttonTextColor = foundation.iron();
+        buttonDecoration =
+            BoxDecoration(color: foundation.melt().withOpacity(0.5));
 
-                return Padding(
-                    padding: EdgeInsets.all(10),
-                    child: StandardButtonElement(
-                      buttonAction: actionItem.onSelection,
-                      buttonTitle: actionItem.actionName,
-                      currentVariant: buttonVariants.darkActive,
-                    ));
-              }));
+        break;
+
+      case buttonVariants.lightActive:
+
+        //variables that define the variant 'light active' for full width buttons
+        isButtonEnabled = true;
+        buttonTextColor = foundation.carbon();
+        buttonDecoration = BoxDecoration(
+            border:
+                Border(top: BorderSide(width: 1, color: foundation.steel())),
+            gradient: foundation.mediumGradient());
+
+        break;
+
+      case buttonVariants.darkActive:
+
+        //variables that define the variant 'dark active' for full width buttons
+        isButtonEnabled = true;
+        buttonTextColor = foundation.melt();
+        buttonDecoration = BoxDecoration(
+            border:
+                Border(top: BorderSide(width: 1, color: foundation.carbon())),
+            gradient: foundation.darkGradient());
+
+        break;
     }
 
     return Container(
-        width: Sizing.widthOf(context: context, weight: sizingWeight.w10),
-        height: Sizing.heightOf(context: context, weight: sizingWeight.w10),
-        padding: EdgeInsets.all(10),
-        child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-          Container(
-              //acts as the "cover" of to the pre-existing view
-              decoration: LayerBackingDecoration(
-                  mode: modeVariants.dark,
-                  priority: decorationPriority.inactive,
-                  variant: layerDecorationVariants.edged) as Decoration),
-          Container(
-              //this will be the rounded card backing
-              height:
-                  Sizing.heightOf(context: context, weight: sizingWeight.w3),
-              child:
-                  Column(mainAxisAlignment: MainAxisAlignment.start, children: [
-                SecondaryIconButtonElement(
-                    currentVariant: buttonVariants.lightActive,
-                    buttonIcon: Assets.no as Icon,
-                    buttonTooltip: 'Exit',
-                    buttonAction: widget.alertData.onCancellation),
-                BadgeElementDarkIcyBoi(),
-                HeadingThreeText(
-                    widget.alertData.alertTitle, foundation.black()),
-                BodyOneText(widget.alertData.alertBody, foundation.black()),
-                alertControllerActions,
-              ]))
-        ]));
+        alignment: Alignment.bottomCenter,
+        padding: EdgeInsets.all(15),
+        decoration: buttonDecoration,
+        width: MediaQuery.of(context).size.width,
+        height: (MediaQuery.of(context).size.height / 10),
+        child: Expanded(
+            child: TextButton(
+                onPressed: isButtonEnabled ? widget.buttonAction : null,
+                child: Text(widget.buttonTitle),
+                style: TextButton.styleFrom(
+                    textStyle:
+                        foundation.button2().copyWith(color: buttonTextColor),
+                    padding: EdgeInsets.all(10),
+                    enableFeedback: true))));
   }
 }

--- a/Codebase/Aureus-Package/lib/Widgets/Components/Alert Controllers/FullWidthAlertControllerComponent.dart
+++ b/Codebase/Aureus-Package/lib/Widgets/Components/Alert Controllers/FullWidthAlertControllerComponent.dart
@@ -5,81 +5,82 @@ import 'package:flutter/cupertino.dart';
 //A full width centered alert controller that sticks to the bottom of the screen
 //Doc Link:
 
-class FullWidthButtonElement extends StatefulWidget {
-  final String buttonTitle;
-  final buttonVariants currentVariant;
-  final VoidCallback buttonAction;
+class FullWidthAlertControllerComponent extends StatefulWidget {
+  final AlertControllerObject alertData;
 
-  const FullWidthButtonElement(
-      {required this.buttonTitle,
-      required this.currentVariant,
-      required this.buttonAction});
+  const FullWidthAlertControllerComponent({required this.alertData});
 
   @override
-  _FullWidthButtonElementState createState() => _FullWidthButtonElementState();
+  _FullWidthAlertControllerComponentState createState() =>
+      _FullWidthAlertControllerComponentState();
 }
 
-class _FullWidthButtonElementState extends State<FullWidthButtonElement> {
-  final foundation = new UDSVariables();
+class _FullWidthAlertControllerComponentState
+    extends State<FullWidthAlertControllerComponent> {
   @override
   Widget build(BuildContext context) {
-    //to fully have the custom functionality wanted, buttons needed to be a pressable container that holds a text button instead of a stock button widget.
+    Expanded alertControllerActions =
+        Expanded(child: Container(width: 10, height: 10));
 
-    //variables that change how the variants are displayed in build time
-    BoxDecoration buttonDecoration;
-    bool isButtonEnabled;
-    Color buttonTextColor;
+    if (widget.alertData.actions.length == 1) {
+      //needs a single full width button
 
-    switch (widget.currentVariant) {
-      case buttonVariants.inactive:
+      var actionItem = widget.alertData.actions[0];
 
-        //variables that define the variant 'inactive' for full width buttons
-        isButtonEnabled = false;
-        buttonTextColor = foundation.iron();
-        buttonDecoration =
-            BoxDecoration(color: foundation.melt().withOpacity(0.5));
+      alertControllerActions = Expanded(
+          child: FullWidthButtonElement(
+        buttonAction: actionItem.onSelection,
+        buttonTitle: actionItem.actionName,
+        currentVariant: buttonVariants.darkActive,
+      ));
+    } else if (widget.alertData.actions.length >= 2) {
+      //needs stacked standards button built to severity
+      alertControllerActions = Expanded(
+          child: ListView.builder(
+              scrollDirection: Axis.vertical,
+              itemCount: widget.alertData.actions.length,
+              itemBuilder: (BuildContext context, int index) {
+                AlertControllerAction actionItem =
+                    widget.alertData.actions[index];
 
-        break;
-
-      case buttonVariants.lightActive:
-
-        //variables that define the variant 'light active' for full width buttons
-        isButtonEnabled = true;
-        buttonTextColor = foundation.carbon();
-        buttonDecoration = BoxDecoration(
-            border:
-                Border(top: BorderSide(width: 1, color: foundation.steel())),
-            gradient: foundation.mediumGradient());
-
-        break;
-
-      case buttonVariants.darkActive:
-
-        //variables that define the variant 'dark active' for full width buttons
-        isButtonEnabled = true;
-        buttonTextColor = foundation.melt();
-        buttonDecoration = BoxDecoration(
-            border:
-                Border(top: BorderSide(width: 1, color: foundation.carbon())),
-            gradient: foundation.darkGradient());
-
-        break;
+                return Padding(
+                    padding: EdgeInsets.all(10),
+                    child: StandardButtonElement(
+                      buttonAction: actionItem.onSelection,
+                      buttonTitle: actionItem.actionName,
+                      currentVariant: buttonVariants.darkActive,
+                    ));
+              }));
     }
 
     return Container(
-        alignment: Alignment.bottomCenter,
-        padding: EdgeInsets.all(15),
-        decoration: buttonDecoration,
-        width: MediaQuery.of(context).size.width,
-        height: (MediaQuery.of(context).size.height / 10),
-        child: Expanded(
-            child: TextButton(
-                onPressed: isButtonEnabled ? widget.buttonAction : null,
-                child: Text(widget.buttonTitle),
-                style: TextButton.styleFrom(
-                    textStyle:
-                        foundation.button2().copyWith(color: buttonTextColor),
-                    padding: EdgeInsets.all(10),
-                    enableFeedback: true))));
+        width: Sizing.widthOf(context: context, weight: sizingWeight.w10),
+        height: Sizing.heightOf(context: context, weight: sizingWeight.w10),
+        padding: EdgeInsets.all(10),
+        child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+          Container(
+              //acts as the "cover" of to the pre-existing view
+              decoration: LayerBackingDecoration(
+                  mode: modeVariants.dark,
+                  priority: decorationPriority.inactive,
+                  variant: layerDecorationVariants.edged) as Decoration),
+          Container(
+              //this will be the rounded card backing
+              height:
+                  Sizing.heightOf(context: context, weight: sizingWeight.w3),
+              child:
+                  Column(mainAxisAlignment: MainAxisAlignment.start, children: [
+                SecondaryIconButtonElement(
+                    currentVariant: buttonVariants.lightActive,
+                    buttonIcon: Assets.no as Icon,
+                    buttonTooltip: 'Exit',
+                    buttonAction: widget.alertData.onCancellation),
+                BadgeElementDarkIcyBoi(),
+                HeadingThreeText(
+                    widget.alertData.alertTitle, foundation.black()),
+                BodyOneText(widget.alertData.alertBody, foundation.black()),
+                alertControllerActions,
+              ]))
+        ]));
   }
 }

--- a/Codebase/Aureus-Package/lib/Widgets/Components/Buttons/FullWidthButtonElement.dart
+++ b/Codebase/Aureus-Package/lib/Widgets/Components/Buttons/FullWidthButtonElement.dart
@@ -20,7 +20,6 @@ class FullWidthButtonElement extends StatefulWidget {
 }
 
 class _FullWidthButtonElementState extends State<FullWidthButtonElement> {
-  final foundation = new UDSVariables();
   @override
   Widget build(BuildContext context) {
     //to fully have the custom functionality wanted, buttons needed to be a pressable container that holds a text button instead of a stock button widget.

--- a/Codebase/Aureus-Package/lib/Widgets/Components/Buttons/FullWidthButtonElement.dart
+++ b/Codebase/Aureus-Package/lib/Widgets/Components/Buttons/FullWidthButtonElement.dart
@@ -20,6 +20,7 @@ class FullWidthButtonElement extends StatefulWidget {
 }
 
 class _FullWidthButtonElementState extends State<FullWidthButtonElement> {
+  final foundation = new UDSVariables();
   @override
   Widget build(BuildContext context) {
     //to fully have the custom functionality wanted, buttons needed to be a pressable container that holds a text button instead of a stock button widget.
@@ -70,7 +71,7 @@ class _FullWidthButtonElementState extends State<FullWidthButtonElement> {
         padding: EdgeInsets.all(15),
         decoration: buttonDecoration,
         width: MediaQuery.of(context).size.width,
-        height: (MediaQuery.of(context).size.height / 7),
+        height: (MediaQuery.of(context).size.height / 10),
         child: Expanded(
             child: TextButton(
                 onPressed: isButtonEnabled ? widget.buttonAction : null,

--- a/Codebase/Aureus-Package/lib/Widgets/Elements/User Input/SingleDataTypeUserInputElement.dart
+++ b/Codebase/Aureus-Package/lib/Widgets/Elements/User Input/SingleDataTypeUserInputElement.dart
@@ -19,7 +19,6 @@ class SingleDataTypeUserInputElement extends StatefulWidget {
 
 class _SingleDataTypeUserInputElementState
     extends State<SingleDataTypeUserInputElement> {
-  final foundation = new UDSVariables();
   @override
   Widget build(BuildContext context) {
     return Padding(

--- a/Codebase/Aureus-Package/lib/Widgets/Elements/User Input/SingleDataTypeUserInputElement.dart
+++ b/Codebase/Aureus-Package/lib/Widgets/Elements/User Input/SingleDataTypeUserInputElement.dart
@@ -19,13 +19,15 @@ class SingleDataTypeUserInputElement extends StatefulWidget {
 
 class _SingleDataTypeUserInputElementState
     extends State<SingleDataTypeUserInputElement> {
+  final foundation = new UDSVariables();
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: EdgeInsets.all(5.0),
       child: Container(
-          width: 250,
-          height: 60,
+          width: Sizing.widthOf(
+              context: MediaQuery.of(context), weight: sizingWeight.w8),
+          height: MediaQuery.of(context).size.height * 0.06,
           decoration: BoxDecoration(
             border: foundation.universalBorder(),
             borderRadius: BorderRadius.all(Radius.circular(10)),
@@ -46,7 +48,7 @@ class _SingleDataTypeUserInputElementState
                     hintStyle: foundation.body1(),
                     hintText: widget.dataPlaceholder),
                 autocorrect: false,
-                textAlign: TextAlign.left,
+                textAlign: TextAlign.center,
                 keyboardType: widget.dataTextType),
           ))),
     );

--- a/Codebase/Aureus-Package/lib/Widgets/Views/SignUpView.dart
+++ b/Codebase/Aureus-Package/lib/Widgets/Views/SignUpView.dart
@@ -5,17 +5,17 @@ import 'package:flutter/cupertino.dart';
 //
 //Doc Link:
 
-class SignInView extends StatefulWidget {
+class SignUpView extends StatefulWidget {
   final modeVariants viewMode;
   final deviceVariants deviceType;
 
-  const SignInView({required this.viewMode, required this.deviceType});
+  const SignUpView({required this.viewMode, required this.deviceType});
 
   @override
-  _SignInViewState createState() => _SignInViewState();
+  _SignUpViewState createState() => _SignUpViewState();
 }
 
-class _SignInViewState extends State<SignInView> {
+class _SignUpViewState extends State<SignUpView> {
   modeVariants _getPillModeVariant() {
     switch (widget.viewMode) {
       case modeVariants.light:

--- a/Codebase/Aureus-Package/lib/Widgets/Views/SignUpView.dart
+++ b/Codebase/Aureus-Package/lib/Widgets/Views/SignUpView.dart
@@ -2,34 +2,165 @@ import 'package:aureus/aureus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 
-//
-//Doc Link:
-
-class SignUpView extends StatefulWidget {
+class SignInView extends StatefulWidget {
   final modeVariants viewMode;
   final deviceVariants deviceType;
+  final List<SingleUserInputTypeObject> listOfUserInputElements;
 
-  const SignUpView({required this.viewMode, required this.deviceType});
+  const SignInView(
+      {required this.viewMode,
+      required this.deviceType,
+      required this.listOfUserInputElements});
 
   @override
-  _SignUpViewState createState() => _SignUpViewState();
+  _SignInViewState createState() => _SignInViewState();
 }
 
-class _SignUpViewState extends State<SignUpView> {
+class _SignInViewState extends State<SignInView> {
+  modeVariants _getPillModeVariant() {
+    switch (widget.viewMode) {
+      case modeVariants.light:
+        {
+          return modeVariants.dark;
+        }
+      case modeVariants.dark:
+        {
+          return modeVariants.light;
+        }
+    }
+  }
+
+  Color _setColourScheme() {
+    switch (widget.viewMode) {
+      case modeVariants.light:
+        {
+          return Colors.white;
+        }
+      case modeVariants.dark:
+        {
+          return Color.fromRGBO(
+              16, 16, 16, 1); //no "obsidian" in foundation colours
+        }
+    }
+  }
+
+  Color _setHeadingColour() {
+    switch (widget.viewMode) {
+      case modeVariants.light:
+        {
+          return Colors.black;
+        }
+      case modeVariants.dark:
+        {
+          return Colors.white;
+        }
+    }
+  }
+
+  Container _getLabelPill(MediaQueryData mediaQueryData) {
+    return Container(
+      width: Sizing.widthOf(context: mediaQueryData, weight: sizingWeight.w3),
+      height: mediaQueryData.size.height *
+          0.035, //cannot fit into any standardized sizing
+      decoration: ButtonBackingDecoration(
+              variant: buttonDecorationVariants.roundedPill,
+              priority: decorationPriority.standard,
+              mode: _getPillModeVariant())
+          .buildBacking(),
+      child: Center(
+        child: TagOneText("subcontext", _setColourScheme()),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    MediaQueryData mediaQueryData = MediaQuery.of(context);
+
     return Container(
-        padding: EdgeInsets.fromLTRB(
-            Sizing.widthOf(context: context, weight: sizingWeight.w0),
-            Sizing.heightOf(context: context, weight: sizingWeight.w1),
-            Sizing.widthOf(context: context, weight: sizingWeight.w0),
-            Sizing.heightOf(context: context, weight: sizingWeight.w0)),
-        width: Sizing.widthOf(context: context, weight: sizingWeight.w10),
-        height: Sizing.heightOf(context: context, weight: sizingWeight.w10),
-        decoration: LayerBackingDecoration(
-            mode: widget.viewMode,
-            priority: decorationPriority.standard,
-            variant: layerDecorationVariants.edged) as Decoration,
-        child: Row(mainAxisAlignment: MainAxisAlignment.center, children: []));
+      decoration: BoxDecoration(color: _setColourScheme()),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Padding(
+            padding: EdgeInsets.only(
+              top: Sizing.heightOf(
+                  context: mediaQueryData, weight: sizingWeight.w0),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: EdgeInsets.only(left: 5),
+                  child: HeadingTwoText("SIGN UP", _setHeadingColour()),
+                ),
+                Padding(
+                  padding: EdgeInsets.only(
+                      left: 5,
+                      top: mediaQueryData.size.height * 0.025,
+                      bottom: mediaQueryData.size.height * 0.015),
+                  child: _getLabelPill(mediaQueryData),
+                ),
+                Container(
+                  height: mediaQueryData.size.height * 0.212,
+                  width: Sizing.widthOf(
+                      weight: sizingWeight.w8, context: mediaQueryData),
+                  child: ListView.builder(
+                    scrollDirection: Axis.vertical,
+                    itemCount: 3,
+                    itemBuilder: (BuildContext context, int index) {
+                      return SingleDataTypeUserInputElement(
+                          //temporarily using this with no dark mode
+                          dataPlaceholder: "item 2",
+                          dataTextType: TextInputType.text);
+                    },
+                  ),
+                ),
+                Padding(
+                  padding: EdgeInsets.only(
+                    left: 5,
+                    top: Sizing.heightOf(
+                        weight: sizingWeight.w0, context: mediaQueryData),
+                    bottom: Sizing.heightOf(
+                        weight: sizingWeight.w0, context: mediaQueryData),
+                  ),
+                  child: Container(
+                    width: Sizing.widthOf(
+                        context: mediaQueryData, weight: sizingWeight.w8),
+                    height: 1,
+                    color: foundation.steel(),
+                  ),
+                ),
+                Padding(
+                    padding: EdgeInsets.only(
+                        left: 5, bottom: mediaQueryData.size.height * 0.015),
+                    child: _getLabelPill(mediaQueryData)),
+                Container(
+                  height: Sizing.heightOf(
+                      weight: sizingWeight.w2, context: mediaQueryData),
+                  width: Sizing.widthOf(
+                      weight: sizingWeight.w8, context: mediaQueryData),
+                  child: ListView.builder(
+                    scrollDirection: Axis.vertical,
+                    itemCount: 2,
+                    itemBuilder: (BuildContext context, int index) {
+                      return SingleDataTypeUserInputElement(
+                          dataPlaceholder: "item 2",
+                          dataTextType: TextInputType.text);
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+          FullWidthButtonElement(
+            buttonTitle: "SIGN UP",
+            currentVariant: buttonVariants.lightActive,
+            buttonAction: () {},
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/Codebase/Aureus-Package/lib/Widgets/Views/SignUpView.dart
+++ b/Codebase/Aureus-Package/lib/Widgets/Views/SignUpView.dart
@@ -2,15 +2,14 @@ import 'package:aureus/aureus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 
+//
+//Doc Link:
+
 class SignInView extends StatefulWidget {
   final modeVariants viewMode;
   final deviceVariants deviceType;
-  final List<SingleUserInputTypeObject> listOfUserInputElements;
 
-  const SignInView(
-      {required this.viewMode,
-      required this.deviceType,
-      required this.listOfUserInputElements});
+  const SignInView({required this.viewMode, required this.deviceType});
 
   @override
   _SignInViewState createState() => _SignInViewState();


### PR DESCRIPTION
Currently implemented with Figma placeholder text and SingleDataTypeUserInputElement (with no dark mode) as BasicInputFormComponent didn't seem to work (can be fixed in another PR). 

All other elements have been setup to change to dark mode as per Figma.

Sizing and format of some other elements have been changed due to compile error or proportion sizes.

A lot of padding cannot be standardized from the Sizing class and had to be custom (decimal). 